### PR TITLE
Update codeclimate-action

### DIFF
--- a/.github/workflows/scala.yml
+++ b/.github/workflows/scala.yml
@@ -19,7 +19,7 @@ jobs:
         cache: sbt
     - run: sbt 'scalafmtCheckAll; scalafmtSbtCheck'
     - run: sbt '+ clean; + coverage; + test; + coverageReport'
-    - uses: paambaati/codeclimate-action@v2.7.5
+    - uses: paambaati/codeclimate-action@v3.2
       env:
         CC_TEST_REPORTER_ID: ${{secrets.CC_TEST_REPORTER_ID}}
       with:


### PR DESCRIPTION
> Node.js 12 actions are deprecated. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/. Please update the following actions to use Node.js 16: paambaati/codeclimate-action